### PR TITLE
chore(readme): update npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Instead of depending on external task runners, Ionic App Scripts now prefers bei
 
 ```
   "scripts": {
-    "build": "ionic-app-scripts build",
-    "watch": "ionic-app-scripts watch"
+    "ionic:build": "ionic-app-scripts build",
+    "ionic:serve": "ionic-app-scripts serve"
   },
 ```
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "github-release": "node ./scripts/create-github-release.js",
     "lint": "tslint -c ./tslint.json --project ./tsconfig.json",
     "nightly": "npm run build && node ./scripts/publish-nightly.js",
-    "release": "npm run build && npm run test && npm version patch && npm changelog && npm run github-release && npm publish",
+    "release": "npm run build && npm run test && npm version patch && npm run changelog && npm run github-release && npm publish",
     "test": "jasmine JASMINE_CONFIG_PATH=src/spec/jasmine.config.json || true",
     "watch": "npm run clean && tsc --watch"
   },


### PR DESCRIPTION
#### Short description of what this resolves:
Readme still shows the old NPM scripts, although both the [changelog](https://github.com/driftyco/ionic-app-scripts/blob/master/CHANGELOG.md) and [blog post](http://blog.ionic.io/improvements-to-ionic-build-process/) recommend using the new ones.